### PR TITLE
Return fill if address not found

### DIFF
--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -32,7 +32,7 @@ namespace intelhex
 	    }
 	    ++i;
 	}
-	return blocks[address][0];
+	return _fill;
     }
 
     // Return the value at address, or _fill if not set


### PR DESCRIPTION
Return fill if address not found for array getter as it is done formal `get()`