### PR TITLE
allow to ignore leaving fill pattern bytes out of hex file

### DIFF
--- a/include/intelhex.h
+++ b/include/intelhex.h
@@ -67,7 +67,7 @@ namespace intelhex
 
 	value_type& operator[](address_type);	//Array access operator
 	value_type  get(address_type);		// Return the value at address
-	void	set(address_type, value_type);	// Set the value at address
+	void	set(address_type, value_type, bool ignore_fill=false);	// Set the value at address
 
 	void	load(const std::string&);	// Load from a file
 	void	read(std::istream &);			// Read data from an input stream

--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -56,9 +56,9 @@ namespace intelhex
     }
 
     // Set the value at address or create a new element using value
-    void hex_data::set(address_type address, value_type value)
+    void hex_data::set(address_type address, value_type value, bool ignore_fill)
     {
-	if( value == fill() )	// Handle fill values
+	if( !ignore_fill && value == fill() )	// Handle fill values
 	{
 	    erase(address);	// If the address is already set, erase it
 	    return;

--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -290,7 +290,7 @@ namespace intelhex
 	while( (i!=blocks.rend()) && (i->first > addr))
 	    ++i;
 
-	if( (addr - i->first) > i->second.size() )
+	if( (addr - i->first) >= i->second.size() )
 	    return false;
 	else
 	    return true;


### PR DESCRIPTION
I needed a way to get a complete hex file as such I needed a way to ignore the skipping of fill pattern bytes... 