### PR TITLE
Correct logic for is_set function

### DIFF
--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -290,7 +290,7 @@ namespace intelhex
 	while( (i!=blocks.rend()) && (i->first > addr))
 	    ++i;
 
-	if( (addr - i->first) > i->second.size() )
+	if( (addr - i->first) >= i->second.size() )
 	    return false;
 	else
 	    return true;


### PR DESCRIPTION
The `is_set()` function was always adding an extra item at the end of a block, hereby this is fixed