### PR TITLE
Fix hang for compact() on empty hex

### DIFF
--- a/include/intelhex.h
+++ b/include/intelhex.h
@@ -67,7 +67,7 @@ namespace intelhex
 
 	value_type& operator[](address_type);	//Array access operator
 	value_type  get(address_type);		// Return the value at address
-	void	set(address_type, value_type);	// Set the value at address
+	void	set(address_type, value_type, bool ignore_fill=false);	// Set the value at address
 
 	void	load(const std::string&);	// Load from a file
 	void	read(std::istream &);			// Read data from an input stream

--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -56,9 +56,9 @@ namespace intelhex
     }
 
     // Set the value at address or create a new element using value
-    void hex_data::set(address_type address, value_type value)
+    void hex_data::set(address_type address, value_type value, bool ignore_fill)
     {
-	if( value == fill() )	// Handle fill values
+	if( !ignore_fill && value == fill() )	// Handle fill values
 	{
 	    erase(address);	// If the address is already set, erase it
 	    return;

--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -290,7 +290,7 @@ namespace intelhex
 	while( (i!=blocks.rend()) && (i->first > addr))
 	    ++i;
 
-	if( (addr - i->first) > i->second.size() )
+	if( (addr - i->first) >= i->second.size() )
 	    return false;
 	else
 	    return true;

--- a/src/intelhex.cc
+++ b/src/intelhex.cc
@@ -93,19 +93,21 @@ namespace intelhex
     // Merge adjacent blocks
     void hex_data::compact()
     {
-	iterator previous = blocks.begin();
-	iterator i = previous;
+        if (blocks.size() > 0) {
+            iterator previous = blocks.begin();
+            iterator i = previous;
 
-	for(++i; i != blocks.end(); ++i)
-	{
-	    if( (previous->first + previous->second.size()) == i->first )
-	    {
-		previous->second.insert(previous->second.end(), i->second.begin(), i->second.end());
-		blocks.erase(i);
-		i = previous;
-	    }
-	    previous = i;
-	}
+            for(++i; i != blocks.end(); ++i)
+            {
+                if( (previous->first + previous->second.size()) == i->first )
+                {
+                    previous->second.insert(previous->second.end(), i->second.begin(), i->second.end());
+                    blocks.erase(i);
+                    i = previous;
+                }
+                previous = i;
+            }
+        }
     }
 
     // Delete all allocated memory


### PR DESCRIPTION
The compact() seemed to be hanging when an empty hex files was loaded.

Hereby trying to fix that.

On top of https://github.com/bfoz/libintelhex/pull/6