### PR TITLE
fix missing cstdint include

### DIFF
--- a/include/intelhex.h
+++ b/include/intelhex.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <unistd.h>
+#include <cstdint>
 
 namespace intelhex
 {


### PR DESCRIPTION
Add 
```c
#include <cstdint.h>
```
to `intelhex.h`