### PR TITLE
Add missing include

### DIFF
--- a/include/intelhex.h
+++ b/include/intelhex.h
@@ -5,7 +5,7 @@
 
 #ifndef INTELHEXH
 #define INTELHEXH
-
+#include <stdint.h>
 #include <iostream>
 #include <map>
 #include <vector>


### PR DESCRIPTION
`intelhex.h` uses fixed width integral types (`uint32_t`) without including the appropriate header: `stdint.h`

This causes a compile error on my platform (MSYS on Win64)